### PR TITLE
Area detection

### DIFF
--- a/src/crosstheborder/lib/Game.java
+++ b/src/crosstheborder/lib/Game.java
@@ -145,18 +145,22 @@ public class Game implements GameManipulator, GameInterface {
 
     @Override
     public void movePlayerEntity(PlayerEntity player, Point nextLocation) {
-        //Check whether there's a tileObject at the next location.
-        if (map.hasTileObject(nextLocation)) {
-            map.getTileObject(nextLocation).interactWith(player, this);
-        }
+        boolean canContinue = true;
 
-        //Check whether there's a PlayerEntity at the next location.
-        if (map.hasPlayerEntity(nextLocation)) {
+        //Check whether the movement would enter a country.
+        if (canContinue && map.hasCountry(nextLocation)) {
+            canContinue = player.interactWith(map.getCountry(nextLocation), this);
+        }
+        //Check whether there's a tileObject at the next location.
+        if (canContinue && map.hasPlayerEntity(nextLocation)) {
             map.getPlayerEntity(nextLocation).interactWith(player, this);
         }
-
+        //Check whether there's a PlayerEntity at the next location.
+        if (canContinue && map.hasTileObject(nextLocation)) {
+            map.getTileObject(nextLocation).interactWith(player, this);
+        }
         //If the tile is free just move the entity.
-        if (!map.hasTileObject(nextLocation) && !map.hasPlayerEntity(nextLocation)) {
+        if (canContinue) {
             changePlayerEntityLocation(player, nextLocation);
         }
     }

--- a/src/crosstheborder/lib/Game.java
+++ b/src/crosstheborder/lib/Game.java
@@ -113,7 +113,7 @@ public class Game implements GameManipulator, GameInterface {
             player = playerEntity;
             players.add(playerEntity);
             Point location = map.getFreePointInArea(team.getTeamArea());
-            changeTileObjectLocation(playerEntity, location);
+            changePlayerEntityLocation(playerEntity, location);
         }
 
         user.setPlayer(player);
@@ -149,9 +149,15 @@ public class Game implements GameManipulator, GameInterface {
         if (map.hasTileObject(nextLocation)) {
             map.getTileObject(nextLocation).interactWith(player, this);
         }
-        //If there is no tileObject move the player.
-        else {
-            changeTileObjectLocation(player, nextLocation);
+
+        //Check whether there's a PlayerEntity at the next location.
+        if (map.hasPlayerEntity(nextLocation)) {
+            map.getPlayerEntity(nextLocation).interactWith(player, this);
+        }
+
+        //If the tile is free just move the entity.
+        if (!map.hasTileObject(nextLocation) && !map.hasPlayerEntity(nextLocation)) {
+            changePlayerEntityLocation(player, nextLocation);
         }
     }
 
@@ -161,7 +167,7 @@ public class Game implements GameManipulator, GameInterface {
         Point nextLocation = map.getFreePointInArea(player.getTeam().getTeamArea());
 
         player.immobilize(settings.getRespawnTime());
-        changeTileObjectLocation(player, nextLocation);
+        changePlayerEntityLocation(player, nextLocation);
     }
 
     @Override
@@ -170,13 +176,28 @@ public class Game implements GameManipulator, GameInterface {
     }
 
     @Override
-    public void changeTileObjectLocation(TileObject tileObject, Point nextLocation) {
-        Point currentLocation = tileObject.getLocation();
+    public void changePlayerEntityLocation(PlayerEntity entity, Point nextLocation) {
+        Point currentLocation = entity.getLocation();
 
-        map.changeTileObject(currentLocation, null);
-        map.changeTileObject(nextLocation, tileObject);
+        map.changePlayerEntity(currentLocation, null);
+        map.changePlayerEntity(nextLocation, entity);
         //Move the location of the entity to the next location. Saves having to recreate a new point object every time.
         currentLocation.move(nextLocation.x, nextLocation.y);
+    }
+
+    @Override
+    public void changeTileObjectLocation(TileObject object, Point nextLocation) {
+        Point currentLocation = object.getLocation();
+
+        map.changeTileObject(currentLocation, null);
+        map.changeTileObject(nextLocation, object);
+        //Move the location of the entity to the next location. Saves having to recreate a new point object every time.
+        currentLocation.move(nextLocation.x, nextLocation.y);
+    }
+
+    @Override
+    public void removeTileObject(TileObject tileObject) {
+        map.changeTileObject(tileObject.getLocation(), null);
     }
 
     @Override

--- a/src/crosstheborder/lib/Game.java
+++ b/src/crosstheborder/lib/Game.java
@@ -153,11 +153,11 @@ public class Game implements GameManipulator, GameInterface {
         }
         //Check whether there's a tileObject at the next location.
         if (canContinue && map.hasPlayerEntity(nextLocation)) {
-            map.getPlayerEntity(nextLocation).interactWith(player, this);
+            canContinue = map.getPlayerEntity(nextLocation).interactWith(player, this);
         }
         //Check whether there's a PlayerEntity at the next location.
         if (canContinue && map.hasTileObject(nextLocation)) {
-            map.getTileObject(nextLocation).interactWith(player, this);
+            canContinue = map.getTileObject(nextLocation).interactWith(player, this);
         }
         //If the tile is free just move the entity.
         if (canContinue) {

--- a/src/crosstheborder/lib/Game.java
+++ b/src/crosstheborder/lib/Game.java
@@ -41,8 +41,8 @@ public class Game implements GameManipulator, GameInterface {
         settings = new GameSettingsImpl(ServerSettings.getInstance().getServerTickRate());
 
         map = MapLoader.getInstance().buildMap(mapName);
-        usa = new Team("USA", map.getUsaArea());
-        mex = new Team("MEX", map.getMexicoArea());
+        usa = new Team("USA", map.getUsaArea(), settings.getUsaScoringModifier());
+        mex = new Team("MEX", map.getMexicoArea(), settings.getMexicanScoringModifier());
     }
 
     /**
@@ -171,8 +171,8 @@ public class Game implements GameManipulator, GameInterface {
     }
 
     @Override
-    public void increaseScore(Team team, int amount) {
-        team.increaseScore(amount);
+    public void increaseScore(Team team) {
+        team.increaseScore();
     }
 
     @Override

--- a/src/crosstheborder/lib/Game.java
+++ b/src/crosstheborder/lib/Game.java
@@ -147,6 +147,10 @@ public class Game implements GameManipulator, GameInterface {
     public void movePlayerEntity(PlayerEntity player, Point nextLocation) {
         boolean canContinue = true;
 
+        //Check whether there's a PlayerEntity at the next location.
+        if (canContinue && map.hasTileObject(nextLocation)) {
+            canContinue = map.getTileObject(nextLocation).interactWith(player, this);
+        }
         //Check whether the movement would enter a country.
         if (canContinue && map.hasCountry(nextLocation)) {
             canContinue = player.interactWith(map.getCountry(nextLocation), this);
@@ -154,10 +158,6 @@ public class Game implements GameManipulator, GameInterface {
         //Check whether there's a tileObject at the next location.
         if (canContinue && map.hasPlayerEntity(nextLocation)) {
             canContinue = map.getPlayerEntity(nextLocation).interactWith(player, this);
-        }
-        //Check whether there's a PlayerEntity at the next location.
-        if (canContinue && map.hasTileObject(nextLocation)) {
-            canContinue = map.getTileObject(nextLocation).interactWith(player, this);
         }
         //If the tile is free just move the entity.
         if (canContinue) {

--- a/src/crosstheborder/lib/Map.java
+++ b/src/crosstheborder/lib/Map.java
@@ -1,5 +1,6 @@
 package crosstheborder.lib;
 
+import crosstheborder.lib.enumeration.Country;
 import crosstheborder.lib.interfaces.Camera;
 import crosstheborder.lib.interfaces.TileObject;
 import crosstheborder.lib.player.PlayerEntity;
@@ -104,6 +105,26 @@ public class Map {
             LOGGER.log(Level.SEVERE, e.toString(), e);
         }
         return null;
+    }
+
+    /**
+     * Gets whether the given location is part of a {@link Country}.
+     *
+     * @param location The location of the tile.
+     * @return A boolean that indicates whether is part of a country.
+     */
+    public boolean hasCountry(Point location) {
+        return getTile(location).getCountry() != Country.NONE;
+    }
+
+    /**
+     * Gets the country of a given location.
+     *
+     * @param location The location of the tile.
+     * @return The country of the tile.
+     */
+    public Country getCountry(Point location) {
+        return getTile(location).getCountry();
     }
 
     /**

--- a/src/crosstheborder/lib/Map.java
+++ b/src/crosstheborder/lib/Map.java
@@ -2,6 +2,7 @@ package crosstheborder.lib;
 
 import crosstheborder.lib.interfaces.Camera;
 import crosstheborder.lib.interfaces.TileObject;
+import crosstheborder.lib.player.PlayerEntity;
 import crosstheborder.lib.tileobject.Placeable;
 
 import java.awt.*;
@@ -135,6 +136,37 @@ public class Map {
     }
 
     /**
+     * Checks whether a given location contains a PlayerEntity.
+     *
+     * @param location The location of the tile that will be checked.
+     * @return A boolean that represents whether a PlayerEntity is present on the tile.
+     */
+    public boolean hasPlayerEntity(Point location) {
+        return getTile(location).hasPlayerEntity();
+    }
+
+    /**
+     * Gets the PlayerEntity at a given location.
+     * Will throw a null reference exception when the tile has no PlayerEntity.
+     *
+     * @param location The location of the tile to get the PlayerEntity from.
+     * @return The PlayerEntity object that belongs to the tile.
+     */
+    public PlayerEntity getPlayerEntity(Point location) {
+        return getTile(location).getPlayerEntity();
+    }
+
+    /**
+     * Changes the PlayerEntity of the given location.
+     *
+     * @param entity   The PlayerEntity that should be placed upon the tile.
+     * @param location The location of the tile.
+     */
+    public void changePlayerEntity(Point location, PlayerEntity entity) {
+        getTile(location).setPlayerEntity(entity);
+    }
+
+    /**
      * Gets a point devoid of a TileObject in a given area.
      * Can be an infinite loop.
      *
@@ -149,7 +181,7 @@ public class Map {
         Point nextLocation = new Point(x, y);
 
         //If the tile is occupied find a new location.
-        if (hasTileObject(nextLocation)) {
+        if (hasTileObject(nextLocation) || hasPlayerEntity(nextLocation)) {
             return getFreePointInArea(area);
         } else {
             return nextLocation;

--- a/src/crosstheborder/lib/MapLoader.java
+++ b/src/crosstheborder/lib/MapLoader.java
@@ -1,5 +1,6 @@
 package crosstheborder.lib;
 
+import crosstheborder.lib.enumeration.Country;
 import crosstheborder.lib.enumeration.ObstacleType;
 import crosstheborder.lib.enumeration.TileType;
 import crosstheborder.lib.interfaces.TileObject;
@@ -99,7 +100,7 @@ public class MapLoader {
         int height = getIntFromLine(heightLine.toString());
         Rectangle usaArea = getAreaFromLine(usaAreaLine.toString());
         Rectangle mexicoArea = getAreaFromLine(mexicoAreaLine.toString());
-        Tile[][] tiles = getTilesFromLines(tileLines, objectLines, width, height);
+        Tile[][] tiles = getTilesFromLines(tileLines, objectLines, width, height, usaArea, mexicoArea);
 
         return new Map.Builder(name).setWidth(width).setHeight(height).setMexicoArea(mexicoArea).setUsaArea(usaArea).setTiles(tiles).build();
     }
@@ -166,15 +167,24 @@ public class MapLoader {
         return new Rectangle(values[0], values[1], values[2], values[3]);
     }
 
-    private Tile[][] getTilesFromLines(List<String> tiles, List<String> objects, int width, int height) {
+    private Tile[][] getTilesFromLines(List<String> tiles, List<String> objects, int width, int height, Rectangle usa, Rectangle mexico) {
         Tile[][] ret = new Tile[width][height];
 
         for (int i = 0; i < width; i++) {
             for (int j = 0; j < height; j++) {
                 char tileCode = tiles.get(i).charAt(j);
                 char objectCode = objects.get(i).charAt(j);
+                Country country;
 
-                ret[i][j] = new Tile(tileTypes.get(tileCode));
+                if (usa.contains(i, j)) {
+                    country = Country.USA;
+                } else if (mexico.contains(i, j)) {
+                    country = Country.MEX;
+                } else {
+                    country = Country.NONE;
+                }
+
+                ret[i][j] = new Tile(tileTypes.get(tileCode), country);
 
                 ObstacleType type = obstacleTypes.get(objectCode);
 

--- a/src/crosstheborder/lib/Team.java
+++ b/src/crosstheborder/lib/Team.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class Team {
     private TeamName name;
     private int score;
+    private int scoreIncrease; //Amount of points to increase each time increaseScore is called.
     private List<Player> teamMembers = new ArrayList();
     private Rectangle teamArea;
 
@@ -22,11 +23,14 @@ public class Team {
      * Constructor of Team class.
      *
      * @param name Name of the team
+     * @param scoreIncrease The amount the score of this team is increased by after each call of increaseScore.
+     * @param teamArea The area of this team.
      */
-    public Team(String name, Rectangle teamArea) {
+    public Team(String name, Rectangle teamArea, int scoreIncrease) {
         this.name = TeamName.valueOf(name);
         this.score = 0;
         this.teamArea = teamArea;
+        this.scoreIncrease = scoreIncrease;
 
     }
 
@@ -59,11 +63,10 @@ public class Team {
     }
 
     /**
-     * Adds the given amount to the team score.
-     * @param amount The amount to increase the score with.
+     * Increases the score of this time.
      */
-    public void increaseScore(int amount) {
-        this.score += amount;
+    public void increaseScore() {
+        this.score += scoreIncrease;
     }
 
     /**

--- a/src/crosstheborder/lib/Tile.java
+++ b/src/crosstheborder/lib/Tile.java
@@ -1,5 +1,6 @@
 package crosstheborder.lib;
 
+import crosstheborder.lib.enumeration.Country;
 import crosstheborder.lib.enumeration.TileType;
 import crosstheborder.lib.interfaces.Drawable;
 import crosstheborder.lib.interfaces.Painter;
@@ -20,14 +21,26 @@ public class Tile implements Drawable {
     private TileObject tileObject;
     private PlayerEntity playerEntity;
     private TileType type;
+    private Country country;
 
     /**
      * Creates a new tile object with the given location.
      *
      * @param type The type of the tile.
+     * @param country The country of this tile.
      */
-    public Tile(TileType type) {
+    public Tile(TileType type, Country country) {
         this.type = type;
+        this.country = country;
+    }
+
+    /**
+     * Gets the country that this tile belongs to.
+     *
+     * @return
+     */
+    public Country getCountry() {
+        return this.country;
     }
 
     /**
@@ -88,6 +101,8 @@ public class Tile implements Drawable {
     public void draw(Painter painter, Point location, int tileWidth) {
         File file = ImageFinder.getInstance().getImage(type);
         painter.drawImage(file, location, tileWidth, tileWidth);
+
+        country.draw(painter, location, tileWidth);
 
         if (hasTileObject()) {
             tileObject.draw(painter, location, tileWidth);

--- a/src/crosstheborder/lib/Tile.java
+++ b/src/crosstheborder/lib/Tile.java
@@ -4,6 +4,7 @@ import crosstheborder.lib.enumeration.TileType;
 import crosstheborder.lib.interfaces.Drawable;
 import crosstheborder.lib.interfaces.Painter;
 import crosstheborder.lib.interfaces.TileObject;
+import crosstheborder.lib.player.PlayerEntity;
 
 import java.awt.*;
 import java.io.File;
@@ -17,6 +18,7 @@ import java.io.File;
  */
 public class Tile implements Drawable {
     private TileObject tileObject;
+    private PlayerEntity playerEntity;
     private TileType type;
 
     /**
@@ -34,7 +36,7 @@ public class Tile implements Drawable {
      * @return True if the tile has a {@link TileObject}. False if it doesn't have a {@link TileObject}.
      */
     public boolean hasTileObject() {
-        return tileObject != null;
+        return this.tileObject != null;
     }
 
     /**
@@ -55,6 +57,33 @@ public class Tile implements Drawable {
         this.tileObject = tileObject;
     }
 
+    /**
+     * Returns whether this tile has a PlayerEntity.
+     *
+     * @return A boolean that indicates whether this tile has a PlayerEntity.
+     */
+    public boolean hasPlayerEntity() {
+        return this.playerEntity != null;
+    }
+
+    /**
+     * Gets the PlayerEntity that lives on this tile.
+     *
+     * @return The PlayerEntity object.
+     */
+    public PlayerEntity getPlayerEntity() {
+        return this.playerEntity;
+    }
+
+    /**
+     * Sets the PlayerEntity of this tile.
+     *
+     * @param playerEntity The PlayerEntity that should occupy this tile.
+     */
+    public void setPlayerEntity(PlayerEntity playerEntity) {
+        this.playerEntity = playerEntity;
+    }
+
     @Override
     public void draw(Painter painter, Point location, int tileWidth) {
         File file = ImageFinder.getInstance().getImage(type);
@@ -62,6 +91,9 @@ public class Tile implements Drawable {
 
         if (hasTileObject()) {
             tileObject.draw(painter, location, tileWidth);
+        }
+        if (hasPlayerEntity()) {
+            playerEntity.draw(painter, location, tileWidth);
         }
     }
 }

--- a/src/crosstheborder/lib/enumeration/Country.java
+++ b/src/crosstheborder/lib/enumeration/Country.java
@@ -1,0 +1,19 @@
+package crosstheborder.lib.enumeration;
+
+import crosstheborder.lib.interfaces.Drawable;
+import crosstheborder.lib.interfaces.Painter;
+
+import java.awt.*;
+
+/**
+ * @author Oscar de Leeuw
+ */
+public enum Country implements Drawable {
+    USA, MEX, NONE;
+
+
+    @Override
+    public void draw(Painter painter, Point location, int tileWidth) {
+        //TODO Add a draw method for painter.
+    }
+}

--- a/src/crosstheborder/lib/enumeration/Country.java
+++ b/src/crosstheborder/lib/enumeration/Country.java
@@ -6,11 +6,12 @@ import crosstheborder.lib.interfaces.Painter;
 import java.awt.*;
 
 /**
+ * Enum for capturing the Countries that can exist within the game.
+ *
  * @author Oscar de Leeuw
  */
 public enum Country implements Drawable {
     USA, MEX, NONE;
-
 
     @Override
     public void draw(Painter painter, Point location, int tileWidth) {

--- a/src/crosstheborder/lib/interfaces/GameManipulator.java
+++ b/src/crosstheborder/lib/interfaces/GameManipulator.java
@@ -24,9 +24,8 @@ public interface GameManipulator {
      * Amount can be negative.
      *
      * @param team   The {@link Team} that should have it's score increased.
-     * @param amount The amount by which the score should be increased.
      */
-    void increaseScore(Team team, int amount);
+    void increaseScore(Team team);
 
     /**
      * Changes the location of a PlayerEntity to new location.

--- a/src/crosstheborder/lib/interfaces/GameManipulator.java
+++ b/src/crosstheborder/lib/interfaces/GameManipulator.java
@@ -29,14 +29,31 @@ public interface GameManipulator {
     void increaseScore(Team team, int amount);
 
     /**
-     * Changes the location of a {@link TileObject} to new location.
+     * Changes the location of a PlayerEntity to new location.
+     * Will not execute if the location is not on the map.
+     * Will remove the PlayerEntity at the newLocation if there is one present.
+     *
+     * @param entity  The PlayerEntity that should be moved.
+     * @param newLocation The new location of the tileObject.
+     */
+    void changePlayerEntityLocation(PlayerEntity entity, Point newLocation);
+
+    /**
+     * Changes the location of a TileObject to new location.
      * Will not execute if the location is not on the map.
      * Will remove the TileObject at the newLocation if there is one present.
      *
-     * @param tileObject  The {@link TileObject} that should be moved.
+     * @param object      The TileObject that should be moved.
      * @param newLocation The new location of the tileObject.
      */
-    void changeTileObjectLocation(TileObject tileObject, Point newLocation);
+    void changeTileObjectLocation(TileObject object, Point newLocation);
+
+    /**
+     * Removes a TileObject from the game.
+     *
+     * @param tileObject The TileObject that should be removed.
+     */
+    void removeTileObject(TileObject tileObject);
 
     /**
      * Moves a player entity to the given location if possible.

--- a/src/crosstheborder/lib/interfaces/TileObject.java
+++ b/src/crosstheborder/lib/interfaces/TileObject.java
@@ -16,8 +16,9 @@ public interface TileObject extends Drawable {
      *
      * @param player The {@link PlayerEntity} that is interacting with the TileObject.
      * @param game A {@link GameManipulator} on which interaction results can be executed.
+     * @return A boolean representing whether further movement/interaction should be evaluated.
      */
-    void interactWith(PlayerEntity player, GameManipulator game);
+    boolean interactWith(PlayerEntity player, GameManipulator game);
 
     /**
      * Gets the location of the {@link TileObject}.

--- a/src/crosstheborder/lib/player/PlayerEntity.java
+++ b/src/crosstheborder/lib/player/PlayerEntity.java
@@ -103,8 +103,9 @@ public abstract class PlayerEntity extends Player implements Drawable {
      *
      * @param player The other PlayerEntity that is interacting with this playerEntity.
      * @param game   A {@link GameManipulator} on which interaction results can be executed.
+     * @return A boolean representing whether further movement/interaction should be evaluated.
      */
-    public abstract void interactWith(PlayerEntity player, GameManipulator game);
+    public abstract boolean interactWith(PlayerEntity player, GameManipulator game);
 
     /**
      * Method for handling the interaction between a PlayerEntity and a country.

--- a/src/crosstheborder/lib/player/PlayerEntity.java
+++ b/src/crosstheborder/lib/player/PlayerEntity.java
@@ -4,6 +4,7 @@ import crosstheborder.lib.ImageFinder;
 import crosstheborder.lib.InputBuffer;
 import crosstheborder.lib.Player;
 import crosstheborder.lib.Team;
+import crosstheborder.lib.enumeration.Country;
 import crosstheborder.lib.enumeration.MoveDirection;
 import crosstheborder.lib.interfaces.*;
 
@@ -104,6 +105,15 @@ public abstract class PlayerEntity extends Player implements Drawable {
      * @param game   A {@link GameManipulator} on which interaction results can be executed.
      */
     public abstract void interactWith(PlayerEntity player, GameManipulator game);
+
+    /**
+     * Method for handling the interaction between a PlayerEntity and a country.
+     *
+     * @param country The country that is being interacted with.
+     * @param game    A GameManipulator on which interaction results can be executed.
+     * @return A boolean representing whether further movement/interaction should be evaluated.
+     */
+    public abstract boolean interactWith(Country country, GameManipulator game);
 
     /**
      * {@inheritDoc}

--- a/src/crosstheborder/lib/player/PlayerEntity.java
+++ b/src/crosstheborder/lib/player/PlayerEntity.java
@@ -5,9 +5,7 @@ import crosstheborder.lib.InputBuffer;
 import crosstheborder.lib.Player;
 import crosstheborder.lib.Team;
 import crosstheborder.lib.enumeration.MoveDirection;
-import crosstheborder.lib.interfaces.GameSettings;
-import crosstheborder.lib.interfaces.Painter;
-import crosstheborder.lib.interfaces.TileObject;
+import crosstheborder.lib.interfaces.*;
 
 import java.awt.*;
 /**
@@ -15,7 +13,7 @@ import java.awt.*;
  *
  * @author Oscar de Leeuw
  */
-public abstract class PlayerEntity extends Player implements TileObject {
+public abstract class PlayerEntity extends Player implements Drawable {
     private Point location;
     private InputBuffer inputBuffer;
     private boolean canMove = true;
@@ -97,6 +95,15 @@ public abstract class PlayerEntity extends Player implements TileObject {
         canMove = false;
         canMoveTicks = serverTickRate * seconds;
     }
+
+    /**
+     * Method for handling the interaction between two PlayerEntities.
+     * Calls methods on the {@link GameManipulator} object to process interaction results.
+     *
+     * @param player The other PlayerEntity that is interacting with this playerEntity.
+     * @param game   A {@link GameManipulator} on which interaction results can be executed.
+     */
+    public abstract void interactWith(PlayerEntity player, GameManipulator game);
 
     /**
      * {@inheritDoc}

--- a/src/crosstheborder/lib/player/entity/BorderPatrol.java
+++ b/src/crosstheborder/lib/player/entity/BorderPatrol.java
@@ -1,6 +1,7 @@
 package crosstheborder.lib.player.entity;
 
 import crosstheborder.lib.Team;
+import crosstheborder.lib.enumeration.Country;
 import crosstheborder.lib.interfaces.GameManipulator;
 import crosstheborder.lib.interfaces.GameSettings;
 import crosstheborder.lib.player.PlayerEntity;
@@ -48,5 +49,14 @@ public class BorderPatrol extends PlayerEntity {
             game.respawnPlayer(player);
             game.changePlayerEntityLocation(this, player.getLocation());
         }
+    }
+
+    @Override
+    public boolean interactWith(Country country, GameManipulator game) {
+        switch (country) {
+            case MEX:
+                return false;
+        }
+        return true;
     }
 }

--- a/src/crosstheborder/lib/player/entity/BorderPatrol.java
+++ b/src/crosstheborder/lib/player/entity/BorderPatrol.java
@@ -36,7 +36,7 @@ public class BorderPatrol extends PlayerEntity {
      * </p>
      * Calls the following methods from GameManipulator:
      * <ul>
-     * <li>{@link GameManipulator#increaseScore(Team, int)} when the other entity is a Mexican.</li>
+     * <li>{@link GameManipulator#increaseScore(Team)} when the other entity is a Mexican.</li>
      * <li>{@link GameManipulator#respawnPlayer(PlayerEntity)} with the Mexican when the other entity is a Mexican.</li>
      * <li>{@link GameManipulator#changePlayerEntityLocation(PlayerEntity, Point)} With itself to the location of the Mexican.</li>
      * </ul>
@@ -44,7 +44,7 @@ public class BorderPatrol extends PlayerEntity {
     @Override
     public void interactWith(PlayerEntity player, GameManipulator game) {
         if (player instanceof Mexican) {
-            game.increaseScore(getTeam(), 1); //TODO Let the score addition be decided by the game.
+            game.increaseScore(getTeam());
             game.respawnPlayer(player);
             game.changePlayerEntityLocation(this, player.getLocation());
         }

--- a/src/crosstheborder/lib/player/entity/BorderPatrol.java
+++ b/src/crosstheborder/lib/player/entity/BorderPatrol.java
@@ -43,12 +43,13 @@ public class BorderPatrol extends PlayerEntity {
      * </ul>
      */
     @Override
-    public void interactWith(PlayerEntity player, GameManipulator game) {
+    public boolean interactWith(PlayerEntity player, GameManipulator game) {
         if (player instanceof Mexican) {
             game.increaseScore(getTeam());
             game.respawnPlayer(player);
             game.changePlayerEntityLocation(this, player.getLocation());
         }
+        return false;
     }
 
     @Override

--- a/src/crosstheborder/lib/player/entity/BorderPatrol.java
+++ b/src/crosstheborder/lib/player/entity/BorderPatrol.java
@@ -3,7 +3,6 @@ package crosstheborder.lib.player.entity;
 import crosstheborder.lib.Team;
 import crosstheborder.lib.interfaces.GameManipulator;
 import crosstheborder.lib.interfaces.GameSettings;
-import crosstheborder.lib.interfaces.TileObject;
 import crosstheborder.lib.player.PlayerEntity;
 
 import java.awt.*;
@@ -39,7 +38,7 @@ public class BorderPatrol extends PlayerEntity {
      * <ul>
      * <li>{@link GameManipulator#increaseScore(Team, int)} when the other entity is a Mexican.</li>
      * <li>{@link GameManipulator#respawnPlayer(PlayerEntity)} with the Mexican when the other entity is a Mexican.</li>
-     * <li>{@link GameManipulator#changeTileObjectLocation(TileObject, Point)} With itself to the location of the Mexican.</li>
+     * <li>{@link GameManipulator#changePlayerEntityLocation(PlayerEntity, Point)} With itself to the location of the Mexican.</li>
      * </ul>
      */
     @Override
@@ -47,7 +46,7 @@ public class BorderPatrol extends PlayerEntity {
         if (player instanceof Mexican) {
             game.increaseScore(getTeam(), 1); //TODO Let the score addition be decided by the game.
             game.respawnPlayer(player);
-            game.changeTileObjectLocation(this, player.getLocation());
+            game.changePlayerEntityLocation(this, player.getLocation());
         }
     }
 }

--- a/src/crosstheborder/lib/player/entity/Mexican.java
+++ b/src/crosstheborder/lib/player/entity/Mexican.java
@@ -1,6 +1,7 @@
 package crosstheborder.lib.player.entity;
 
 import crosstheborder.lib.Team;
+import crosstheborder.lib.enumeration.Country;
 import crosstheborder.lib.interfaces.GameManipulator;
 import crosstheborder.lib.interfaces.GameSettings;
 import crosstheborder.lib.player.PlayerEntity;
@@ -77,5 +78,16 @@ public class Mexican extends PlayerEntity {
             game.increaseScore(player.getTeam());
             game.respawnPlayer(this);
         }
+    }
+
+    @Override
+    public boolean interactWith(Country country, GameManipulator game) {
+        switch (country) {
+            case USA:
+                game.increaseScore(this.getTeam());
+                game.respawnPlayer(this);
+                return false;
+        }
+        return true;
     }
 }

--- a/src/crosstheborder/lib/player/entity/Mexican.java
+++ b/src/crosstheborder/lib/player/entity/Mexican.java
@@ -67,14 +67,14 @@ public class Mexican extends PlayerEntity {
      * </p>
      * Calls the following methods from GameManipulator:
      * <ul>
-     * <li>Calls {@link GameManipulator#increaseScore(Team, int)} when the other entity is a BorderPatrol.</li>
+     * <li>Calls {@link GameManipulator#increaseScore(Team)} when the other entity is a BorderPatrol.</li>
      * <li>Calls {@link GameManipulator#respawnPlayer(PlayerEntity)} with itself when the other entity is a BorderPatrol.</li>
      * </ul>
      */
     @Override
     public void interactWith(PlayerEntity player, GameManipulator game) {
         if (player instanceof BorderPatrol) {
-            game.increaseScore(player.getTeam(), 1); //TODO Let the game decide the amount.
+            game.increaseScore(player.getTeam());
             game.respawnPlayer(this);
         }
     }

--- a/src/crosstheborder/lib/player/entity/Mexican.java
+++ b/src/crosstheborder/lib/player/entity/Mexican.java
@@ -73,11 +73,12 @@ public class Mexican extends PlayerEntity {
      * </ul>
      */
     @Override
-    public void interactWith(PlayerEntity player, GameManipulator game) {
+    public boolean interactWith(PlayerEntity player, GameManipulator game) {
         if (player instanceof BorderPatrol) {
             game.increaseScore(player.getTeam());
             game.respawnPlayer(this);
         }
+        return false;
     }
 
     @Override

--- a/src/crosstheborder/lib/tileobject/Obstacle.java
+++ b/src/crosstheborder/lib/tileobject/Obstacle.java
@@ -35,7 +35,8 @@ public class Obstacle implements TileObject {
      * {@inheritDoc}
      */
     @Override
-    public void interactWith(PlayerEntity player, GameManipulator game) {
+    public boolean interactWith(PlayerEntity player, GameManipulator game) {
+        return false;
     }
 
     @Override

--- a/src/crosstheborder/lib/tileobject/Placeable.java
+++ b/src/crosstheborder/lib/tileobject/Placeable.java
@@ -23,7 +23,7 @@ public abstract class Placeable implements TileObject {
         this.location = new Point();
     }
 
-    public abstract void interactWith(PlayerEntity player, GameManipulator game);
+    public abstract boolean interactWith(PlayerEntity player, GameManipulator game);
 
     /**
      * Checks what the placement rules are of a placeable.

--- a/src/crosstheborder/lib/tileobject/placeable/Trap.java
+++ b/src/crosstheborder/lib/tileobject/placeable/Trap.java
@@ -17,6 +17,7 @@ import java.awt.*;
 public class Trap extends Placeable {
     //The time the trap will immobilize a Mexican in seconds.
     private int trapTime;
+    private int trapUses;
 
     /**
      * Creates a new trap object.
@@ -26,6 +27,7 @@ public class Trap extends Placeable {
      */
     public Trap(GameSettings settings) {
         this.trapTime = settings.getDefaultTrapTime();
+        this.trapUses = 1; //TODO set this in gameSettings.
     }
 
     /**
@@ -36,7 +38,8 @@ public class Trap extends Placeable {
      * </p>
      * Calls the following methods from GameManipulator:
      * <ul>
-     *     <li>Calls {@link GameManipulator#changeTileObjectLocation(TileObject, Point)} when the PlayerEntity is a Mexican.</li>
+     *     <li>Calls {@link GameManipulator#changePlayerEntityLocation(PlayerEntity, Point)} when the PlayerEntity is a Mexican.</li>
+     *     <li>Calls {@link GameManipulator#removeTileObject(TileObject)} with itself if the trap has no uses left.</li>
      * </ul>
      */
     @Override
@@ -44,11 +47,14 @@ public class Trap extends Placeable {
         //Trap the player if it is a mexican.
         if (player instanceof Mexican) {
             player.immobilize(trapTime);
-            //Removes the trap and relocates the player to the location of the trap.
-            game.changeTileObjectLocation(player, this.getLocation());
+            trapUses--;
         }
 
+        if (trapUses == 0) {
+            game.removeTileObject(this);
+        }
 
+        game.changePlayerEntityLocation(player, this.getLocation());
     }
 
     /**

--- a/src/crosstheborder/lib/tileobject/placeable/Trap.java
+++ b/src/crosstheborder/lib/tileobject/placeable/Trap.java
@@ -43,18 +43,17 @@ public class Trap extends Placeable {
      * </ul>
      */
     @Override
-    public void interactWith(PlayerEntity player, GameManipulator game) {
+    public boolean interactWith(PlayerEntity player, GameManipulator game) {
         //Trap the player if it is a mexican.
         if (player instanceof Mexican) {
             player.immobilize(trapTime);
+
             trapUses--;
+            if (trapUses == 0) {
+                game.removeTileObject(this);
+            }
         }
-
-        if (trapUses == 0) {
-            game.removeTileObject(this);
-        }
-
-        game.changePlayerEntityLocation(player, this.getLocation());
+        return true;
     }
 
     /**

--- a/src/crosstheborder/lib/tileobject/placeable/Wall.java
+++ b/src/crosstheborder/lib/tileobject/placeable/Wall.java
@@ -42,17 +42,18 @@ public class Wall extends Placeable {
      * </p>
      * Calls the following methods from GameManipulator:
      * <ul>
-     *     <li>Calls {@link GameManipulator#changePlayerEntityLocation(TileObject, Point)} when the PlayerEntity is a Mexican and the wall in successfully climbed.</li>
+     *     <li>Calls {@link GameManipulator#changePlayerEntityLocation(PlayerEntity, Point)} when the PlayerEntity is a Mexican and the wall in successfully climbed.</li>
      * </ul>
      */
     @Override
-    public void interactWith(PlayerEntity player, GameManipulator game) {
+    public boolean interactWith(PlayerEntity player, GameManipulator game) {
         if (player instanceof Mexican) {
             //If the mexican can scale walls
             if (((Mexican) player).climbWall(this)) {
                 throwMexicanOverWall(player, game);
             }
         }
+        return false;
     }
 
     /**

--- a/src/crosstheborder/lib/tileobject/placeable/Wall.java
+++ b/src/crosstheborder/lib/tileobject/placeable/Wall.java
@@ -42,7 +42,7 @@ public class Wall extends Placeable {
      * </p>
      * Calls the following methods from GameManipulator:
      * <ul>
-     *     <li>Calls {@link GameManipulator#changeTileObjectLocation(TileObject, Point)} when the PlayerEntity is a Mexican and the wall in successfully climbed.</li>
+     *     <li>Calls {@link GameManipulator#changePlayerEntityLocation(TileObject, Point)} when the PlayerEntity is a Mexican and the wall in successfully climbed.</li>
      * </ul>
      */
     @Override

--- a/test/crosstheborder/lib/GameTest.java
+++ b/test/crosstheborder/lib/GameTest.java
@@ -56,8 +56,8 @@ public class GameTest {
         assertTrue(borderPatrol.getTeam().getTeamArea().contains(borderPatrol.getLocation()));
 
         //Check if the mexican and borderpatrol exist on the map.
-        assertEquals(game.getMap().getTileObject(mexican.getLocation()), mexican);
-        assertEquals(game.getMap().getTileObject(borderPatrol.getLocation()), borderPatrol);
+        assertEquals(game.getMap().getPlayerEntity(mexican.getLocation()), mexican);
+        assertEquals(game.getMap().getPlayerEntity(borderPatrol.getLocation()), borderPatrol);
 
         //Check whether the teams contain the correct team members.
         assertTrue(game.getUsa().getTeamMembers().contains(borderPatrol));
@@ -147,7 +147,7 @@ public class GameTest {
         //Move the player to an empty tile.
         game.movePlayerEntity(mexican, nextLocation1);
 
-        assertEquals(mexican, game.getMap().getTileObject(nextLocation1));
+        assertEquals(mexican, game.getMap().getPlayerEntity(nextLocation1));
         assertFalse(game.getMap().hasTileObject(oldLocation));
         assertEquals(mexican.getLocation().x, nextLocation1.x);
         assertEquals(mexican.getLocation().y, nextLocation1.y);
@@ -161,8 +161,8 @@ public class GameTest {
         game.movePlayerEntity(mexican, nextLocation2);
 
         //Mexican should not have moved.
-        assertEquals(mexican, game.getMap().getTileObject(mexican.getLocation()));
-        assertEquals(mexican, game.getMap().getTileObject(nextLocation1));
+        assertEquals(mexican, game.getMap().getPlayerEntity(mexican.getLocation()));
+        assertEquals(mexican, game.getMap().getPlayerEntity(nextLocation1));
         assertEquals(obstacle, game.getMap().getTileObject(nextLocation2));
     }
 
@@ -206,9 +206,9 @@ public class GameTest {
         Point oldLocation = new Point(playerLocation.x, playerLocation.y);
         Point nextLocation = new Point(playerLocation.x + 1, playerLocation.y);
 
-        game.changeTileObjectLocation(mexican, nextLocation);
+        game.changePlayerEntityLocation(mexican, nextLocation);
 
-        assertEquals(mexican, game.getMap().getTileObject(nextLocation));
+        assertEquals(mexican, game.getMap().getPlayerEntity(nextLocation));
         assertFalse(game.getMap().hasTileObject(oldLocation));
         assertEquals(mexican.getLocation().x, nextLocation.x);
         assertEquals(mexican.getLocation().y, nextLocation.y);

--- a/test/crosstheborder/lib/GameTest.java
+++ b/test/crosstheborder/lib/GameTest.java
@@ -180,14 +180,12 @@ public class GameTest {
     public void increaseScore() throws Exception {
         int initUsaScore = game.getUsa().getScore();
         int initMexScore = game.getUsa().getScore();
-        int amount1 = 1;
-        int amount2 = 3;
 
-        game.increaseScore(borderPatrol.getTeam(), amount1);
-        game.increaseScore(mexican.getTeam(), amount2);
+        game.increaseScore(borderPatrol.getTeam());
+        game.increaseScore(mexican.getTeam());
 
-        assertEquals(initUsaScore + amount1, game.getUsa().getScore());
-        assertEquals(initMexScore + amount2, game.getMexico().getScore());
+        assertEquals(initUsaScore + 1, game.getUsa().getScore());
+        assertEquals(initMexScore + 1, game.getMexico().getScore());
     }
 
     @Test


### PR DESCRIPTION
Tiles now know about a TileObject, PlayerEntity and Country.
Mexicans now score when they enter a tile with Country.USA.
BorderPatrol can't enter tiles that are Country,MEX.
Traps have uses now.

Fixes #45 
Fixes #76 